### PR TITLE
Build eclipse plugin with tycho

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,10 +22,12 @@
   <parent>
     <groupId>com.google.googlejavaformat</groupId>
     <artifactId>google-java-format-parent</artifactId>
-    <version>1.8-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>google-java-format</artifactId>
+  <version>${revision}</version>
+  <packaging>jar</packaging>
 
   <name>Google Java Format</name>
 

--- a/eclipse_plugin/META-INF/MANIFEST.MF
+++ b/eclipse_plugin/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: google-java-format
 Bundle-SymbolicName: google-java-format-eclipse-plugin;singleton:=true
-Bundle-Version: 1.6.0
+Bundle-Version: 1.8.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.jdt.core;bundle-version="3.10.0",
  org.eclipse.jface,
@@ -10,6 +10,6 @@ Require-Bundle: org.eclipse.jdt.core;bundle-version="3.10.0",
  org.eclipse.ui,
  org.eclipse.equinox.common
 Bundle-ClassPath: .,
- lib/guava-22.0.jar,
+ lib/guava-28.1-jre.jar,
  lib/javac-shaded-9+181-r4173-1.jar,
- lib/google-java-format-1.6.jar
+ lib/google-java-format-1.8.0-SNAPSHOT.jar

--- a/eclipse_plugin/README.md
+++ b/eclipse_plugin/README.md
@@ -6,21 +6,21 @@ See https://github.com/google/google-java-format#eclipse
 
 ## Development
 
+### Prerequisites
+
+If you build a `-SNAPSHOT` build make sure the version in the manifest file uses the qualifier `.qualifier` (that is filled
+with a date version qualifier by the tycho plugin) and the `revision` property in the parent pom uses the qualifier `-SNAPSHOT`.
+If you build a release make sure to remove `.qualifier`.
+
+Make sure that the jars referenced in `build.properties` and `META-INF/MANIFEST.MF` (in `lib/`)
+comply with the set of runtime dependencies required for the core jar.
+
+### Build Dropin
+
 1) Uncomment `<module>eclipse_plugin</module>` in the parent `pom.xml`
 
 2) Run `mvn install`, which will copy the dependences of the plugin to
-`eclipse_plugin/lib`.
+`eclipse_plugin/lib` and triggers the tycho build that uses the `eclipse_plugin/lib` (because of the
+definition in the build.properties file).
 
-2) If you are using Java 9, add
-
-    ```
-    -vm
-    /Library/Java/JavaVirtualMachines/jdk1.8.0_91.jdk/Contents/Home/bin/java
-    ```
-
-    to `/Applications/Eclipse.app/Contents/Eclipse/eclipse.ini`.
-
-3) Open the `eclipse_plugin` project in a recent Eclipse SDK build.
-
-4) From `File > Export` select `Plugin-in Development > Deployable plugin-ins
-and fragments` and follow the wizard to export a plugin jar.
+3) You find the dropin here: `eclipse_plugin/target/google-java-format-eclipse-plugin-<version>.jar`

--- a/eclipse_plugin/build.properties
+++ b/eclipse_plugin/build.properties
@@ -4,5 +4,5 @@ bin.includes = META-INF/,\
                .,\
                plugin.xml,\
                lib/javac-shaded-9+181-r4173-1.jar,\
-               lib/guava-22.0.jar,\
-               lib/google-java-format-1.6.jar
+               lib/guava-28.1-jre.jar,\
+               lib/google-java-format-1.8.0-SNAPSHOT.jar

--- a/eclipse_plugin/pom.xml
+++ b/eclipse_plugin/pom.xml
@@ -33,7 +33,7 @@
   </description>
 
   <properties>
-    <tycho-version>0.26.0</tycho-version>
+    <tycho-version>1.6.0</tycho-version>
   </properties>
 
   <repositories>

--- a/eclipse_plugin/pom.xml
+++ b/eclipse_plugin/pom.xml
@@ -20,11 +20,11 @@
   <parent>
     <groupId>com.google.googlejavaformat</groupId>
     <artifactId>google-java-format-parent</artifactId>
-    <version>1.6</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>google-java-format-eclipse-plugin</artifactId>
-  <version>1.6.0</version>
+  <version>${revision}</version>
   <packaging>eclipse-plugin</packaging>
   <name>google-java-format Plugin for Eclipse 4.5+</name>
 
@@ -48,13 +48,12 @@
     <dependency>
       <groupId>com.google.googlejavaformat</groupId>
       <artifactId>google-java-format</artifactId>
-      <version>1.6</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 
   <build>
     <plugins>
-
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
     <module>core</module>
     <!-- google-java-format#24
     <module>idea_plugin</module>
-    <module>eclipse_plugin</module>
     -->
+    <module>eclipse_plugin</module>
   </modules>
 
   <name>Google Java Format Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <groupId>com.google.googlejavaformat</groupId>
   <artifactId>google-java-format-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.8-SNAPSHOT</version>
+  <version>${revision}</version>
 
   <modules>
     <module>core</module>
@@ -89,10 +89,11 @@
   </issueManagement>
 
   <prerequisites>
-    <maven>3.0.3</maven>
+    <maven>3.5.0</maven>
   </prerequisites>
 
   <properties>
+    <revision>1.8.0-SNAPSHOT</revision>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
     <guava.version>28.1-jre</guava.version>


### PR DESCRIPTION
Directly uses the dependencies located
in the lib directory filled by the core's
build process.
Uses the property "revision" (usable with
maven >= 3.5.0) to use a consistent version
handling.